### PR TITLE
Added more PyPy and aarch64 jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,7 @@ jobs:
       os: linux
       env:
         - MB_PYTHON_VERSION=pypy3.6-7.3.1
-        - MB_ML_VER=2010
+        - MB_ML_VER=2014
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
         - LATEST="true"
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -160,6 +160,35 @@ jobs:
         - PLAT=i686
         - LATEST="true"
 
+    - name: "3.6 Xenial 64-bit PyPy"
+      os: linux
+      env:
+        - MB_PYTHON_VERSION=pypy3.6-7.3.1
+        - MB_ML_VER=2010
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+        - LATEST="true"
+    - os: linux
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.6
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+    - os: linux
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.8
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+    - os: linux
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.7
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+
 
 before_install:
     - source multibuild/common_utils.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,7 @@ jobs:
       os: linux
       env:
         - MB_PYTHON_VERSION=pypy3.6-7.3.1
-        - MB_ML_VER=2014
+        - MB_ML_VER=2010
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
         - LATEST="true"
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
       - PLAT=x86_64
       - UNICODE_WIDTH=32
       - BUILD_DEPENDS=""
-      - TEST_DEPENDS="pytest pytest-cov numpy"
+      - TEST_DEPENDS="pytest pytest-cov"
       - MACOSX_DEPLOYMENT_TARGET=10.10
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
       # Following generated with

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,13 @@ jobs:
         - MB_PYTHON_VERSION=3.8
         - PLAT=i686
 
+    - name: "3.6 Xenial 64-bit PyPy"
+      os: linux
+      env:
+        - MB_PYTHON_VERSION=pypy3.6-7.3.1
+        - MB_ML_VER=2010
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+
     - name: "3.6 Xenial aarch64"
       arch: arm64
       env:
@@ -183,7 +190,7 @@ jobs:
         - PLAT=i686
         - LATEST="true"
 
-    - name: "3.6 Xenial 64-bit PyPy"
+    - name: "3.6 Xenial 64-bit PyPy latest"
       os: linux
       env:
         - MB_PYTHON_VERSION=pypy3.6-7.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,14 @@ jobs:
         - MB_PYTHON_VERSION=3.8
         - PLAT=i686
 
+    - name: "3.6 macOS PyPy"
+      os: osx
+      osx_image: xcode9.3
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=pypy3.6-7.3.1
+        - MB_PYTHON_OSX_VER=10.9
+
     - name: "3.6 Xenial 64-bit PyPy"
       os: linux
       env:
@@ -188,6 +196,15 @@ jobs:
       env:
         - MB_PYTHON_VERSION=3.8
         - PLAT=i686
+        - LATEST="true"
+
+    - name: "3.6 macOS PyPy latest"
+      os: osx
+      osx_image: xcode9.3
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=pypy3.6-7.3.1
+        - MB_PYTHON_OSX_VER=10.9
         - LATEST="true"
 
     - name: "3.6 Xenial 64-bit PyPy latest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,29 @@ jobs:
         - MB_PYTHON_VERSION=3.8
         - PLAT=i686
 
+    - name: "3.6 Xenial aarch64"
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.6
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+    - name: "3.7 Xenial aarch64"
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.7
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+    - name: "3.8 Xenial aarch64"
+      os: linux
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.8
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+
     - name: "3.5 macOS latest"
       os: osx
       osx_image: xcode9.3
@@ -167,27 +190,34 @@ jobs:
         - MB_ML_VER=2010
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
         - LATEST="true"
-    - os: linux
+
+    - name: "3.6 Xenial arm64 latest"
+      os: linux
       arch: arm64
       env:
         - PLAT=aarch64
         - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.6
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
-    - os: linux
-      arch: arm64
-      env:
-        - PLAT=aarch64
-        - MB_ML_VER=2014
-        - MB_PYTHON_VERSION=3.8
-        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
-    - os: linux
+        - LATEST="true"
+    - name: "3.7 Xenial aarch64 latest"
+      os: linux
       arch: arm64
       env:
         - PLAT=aarch64
         - MB_ML_VER=2014
         - MB_PYTHON_VERSION=3.7
         - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+        - LATEST="true"
+    - name: "3.8 Xenial aarch64 latest"
+      os: linux
+      arch: arm64
+      env:
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - MB_PYTHON_VERSION=3.8
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+        - LATEST="true"
 
 
 before_install:

--- a/config.sh
+++ b/config.sh
@@ -24,6 +24,16 @@ function pre_build {
     if [ -n "$IS_OSX" ]; then
         # Update to latest zlib for OS X build
         build_new_zlib
+    elif [ $MB_ML_VER -eq 2014 ]; then
+        yum install -y cmake
+    
+        function get_cmake {
+            echo cmake
+        }
+
+        function build_xz {
+            yum install -y xz-devel
+        }
     fi
     
     # Custom flags to include both multibuild and jpeg defaults

--- a/config.sh
+++ b/config.sh
@@ -25,13 +25,17 @@ function pre_build {
         # Update to latest zlib for OS X build
         build_new_zlib
     elif [ $MB_ML_VER -eq 2014 ]; then
+        # Override multibuild's get_cmake which tries to install a very old
+        # version of cmake not available on manylinux2014
         yum install -y cmake
-    
+
         function get_cmake {
             echo cmake
         }
 
         function build_xz {
+            # Override multibuild's build_xz since it installs a multibuild1
+            # version which breaks yum
             yum install -y xz-devel
         }
     fi

--- a/config.sh
+++ b/config.sh
@@ -83,6 +83,12 @@ EXP_CODECS="jpg jpg_2000 libtiff zlib"
 EXP_MODULES="freetype2 littlecms2 pil tkinter webp"
 
 function run_tests {
+    if [ -n "$IS_OSX" ]; then
+		brew install openblas
+		echo -e "[openblas]\nlibraries = openblas\nlibrary_dirs = /usr/local/opt/openblas/lib" >> ~/.numpy-site.cfg
+	fi
+	pip install numpy
+	
     # Runs tests on installed distribution from an empty directory
     (cd ../Pillow && run_tests_in_repo)
     # Show supported codecs and modules


### PR DESCRIPTION
Helps https://github.com/python-pillow/pillow-wheels/pull/147

Copies the PyPy and aarch64 jobs so that we have LATEST and stable versions

Also updates multibuild to include https://github.com/matthew-brett/multibuild/pull/334, to then add macOS PyPy jobs.
That then leads to the commit installing NumPy with OpenBLAS, similar to https://github.com/python-pillow/Pillow/pull/4711